### PR TITLE
🎨 Add orders app URLs to project urlpatterns

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     path("api/admin/product/", include("apps.products.admin_urls")),
     path('api/user/', include('apps.users.urls')),
     path('api/admin/user/', include('apps.users.admin_urls')),
+    path('api/orders/', include('apps.orders.urls')),
 ]


### PR DESCRIPTION
- Included apps.orders.urls in project urls.py
- Ensures that CartViewSet and OrderViewSet endpoints are reachable
- Allows API requests to /api/orders/ and /api/cart/ to function properly