### PR TITLE
✨ orders API 경로 수정 및 PATCH/DELETE 제거

### DIFF
--- a/apps/orders/urls.py
+++ b/apps/orders/urls.py
@@ -4,7 +4,7 @@ from rest_framework.routers import DefaultRouter
 from .views import OrderViewSet
 
 router = DefaultRouter()
-router.register(r"", OrderViewSet, basename="orders")  # <- prefix를 빈 문자열로 변경
+router.register(r"order", OrderViewSet, basename="order")  # prefix와 basename 변경
 
 urlpatterns = [
     path("", include(router.urls)),


### PR DESCRIPTION
- Swagger 및 DRF OrderViewSet 엔드포인트 경로를 /orders/ -> /order/로 변경
- OrderViewSet에서 PATCH(partial_update) 및 DELETE(orders_delete) 메서드 제거
  - PATCH: 부분 수정 기능 (명세서에 정의되지 않음)
  - DELETE: 주문 전체 삭제 기능 (명세서에 정의되지 않음)
- http_method_names를 ['get', 'post', 'put']으로 제한하여 불필요한 엔드포인트 비활성화
- urls.py에서 router prefix와 basename을 'order'로 통일
- Swagger 문서 반영: 불필요한 엔드포인트 제거, 명세서와 일치하도록 수정