### PR TITLE
✨🔧 fix: orders 앱 URL 중복 제거 및 엔드포인트 통일

### DIFF
--- a/apps/orders/urls.py
+++ b/apps/orders/urls.py
@@ -1,10 +1,11 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
-
 from .views import OrderViewSet
 
 router = DefaultRouter()
-router.register(r"order", OrderViewSet, basename="order")  # prefix와 basename 변경
+router.register(r"", OrderViewSet, basename="order")  # ✅ prefix를 빈 문자열로 변경
+
+app_name = "order"
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,23 +6,6 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
-"""
-URL configuration for config project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-
 schema_view = get_schema_view(
     openapi.Info(
         title="Project API",
@@ -35,25 +18,25 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+
     # 앱 API
     path("api/product/", include("apps.products.urls")),
-    path(
-        "api/admin/product/", include(("apps.products.admin_urls", "products_admin"), namespace="products_admin")
-    ),  # include튜플 & namespace지정
+    path("api/admin/product/", include(("apps.products.admin_urls", "products_admin"), namespace="products_admin")),
     path("api/user/", include("apps.users.urls")),
     path("api/admin/user/", include("apps.users.admin_urls")),
-    path("api/orders/", include("apps.orders.urls")),
+    path("api/order/", include("apps.orders.urls")),  # ✅ config에서 api/order/로 감싸기
     path("api/cart/", include("apps.carts.urls")),
     path("api/payment/", include("apps.payments.urls")),
     path("api/admin/payment/", include("apps.payments.admin_urls")),
-    # Swagger 문서 (로그인 없이 테스트)
+
+    # Swagger 문서
     path("swagger/", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
     path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+
+    # 인증
     path("accounts/", include("django.contrib.auth.urls")),
-    # 콜백 처리용
     path("accounts/", include("allauth.urls")),
 ]
 
-# 개발 환경에서 static 파일 서빙
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
✅ apps/orders/urls.py
   - Router prefix를 빈 문자열("")로 변경하여 /order/order/ → /order/로 수정

✅ config/urls.py
   - /api/order/로 경로 통일

✅ 엔드포인트 구조
   - GET    /api/order/       -> order-list
   - POST   /api/order/       -> order-list (create)
   - GET    /api/order/{id}/  -> order-detail
   - PUT    /api/order/{id}/  -> order-detail

💡 Swagger 및 브라우저에서 /api/order/ 경로로 확인 가능