### PR TITLE
🚫 관리자 주문 생성 기능 제한

### DIFF
--- a/apps/orders/admin_views.py
+++ b/apps/orders/admin_views.py
@@ -12,7 +12,7 @@ class AdminOrderViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAdminUser]
     pagination_class = CustomPagination
 
-    http_method_names = ["get", "post", "put", "delete"]  # PATCH 제거
+    http_method_names = ["get", "put", "delete"]  # PATCH 제거
 
     def get_queryset(self):
         if getattr(self, "swagger_fake_view", False):


### PR DESCRIPTION
- AdminOrderViewSet의 http_method_names에서 'post' 제거
  → 관리자가 직접 주문을 생성하지 못하도록 제한
- 조회(GET), 수정(PUT), 삭제(DELETE)는 여전히 가능
- 부분 수정(PATCH) 기능은 이미 비활성화 상태